### PR TITLE
Compiles + small qol

### DIFF
--- a/src/aquarion/blocks/AquaCrafters.java
+++ b/src/aquarion/blocks/AquaCrafters.java
@@ -27,7 +27,7 @@ public class AquaCrafters {
     envEnabled|= Env.terrestrial | Env.underwater;
     envDisabled|= Env.spores | Env.scorching;
     squareSprite = false;
-    consume(new ConsumeRT(10));;
+    consume(new ConsumeRT(10));
     }};
     }
 }

--- a/src/aquarion/blocks/AquaDistribution.java
+++ b/src/aquarion/blocks/AquaDistribution.java
@@ -53,15 +53,6 @@ public class AquaDistribution {
             envDisabled |= Env.spores | Env.scorching;
         }};
 
-        manganeseConveyor = new SealedConveyor("manganese-conveyor"){{
-            requirements(category.distribution, with(manganese, 1, gallium, 1, bauxite, 2));
-            speed = 4f;
-            stopSpeed = 45;
-            visualSpeed = 20;
-            envEnabled |= Env.terrestrial | Env.underwater;
-            envDisabled |= Env.spores | Env.scorching;
-        }};
-
         sealedRouter = new Router("sealed-router"){{
             requirements(category.distribution, with(lead, 10, bauxite, 5));
             envEnabled |= Env.terrestrial | Env.underwater;
@@ -82,6 +73,17 @@ public class AquaDistribution {
             speed = 90;
             fadeIn = moveArrows = pulse = true;
             arrowSpacing = 4;
+            envEnabled |= Env.terrestrial | Env.underwater;
+            envDisabled |= Env.spores | Env.scorching;
+        }};
+        
+        manganeseConveyor = new SealedConveyor("manganese-conveyor"){{
+            //Since `manganeseBridge instanceof DuctBridge` is false this doesn't work
+            //bridgeReplacement = manganeseBridge;
+            requirements(category.distribution, with(manganese, 1, gallium, 1, bauxite, 2));
+            speed = 4f;
+            stopSpeed = 45;
+            visualSpeed = 20;
             envEnabled |= Env.terrestrial | Env.underwater;
             envDisabled |= Env.spores | Env.scorching;
         }};

--- a/src/aquarion/blocks/TorqueBlocks.java
+++ b/src/aquarion/blocks/TorqueBlocks.java
@@ -17,7 +17,7 @@ public class TorqueBlocks {
 
     public static void loadContent() {
         torqueSource = new RTGenericCrafter("torque-source"){{
-            buildVisibility = BuildVisibility.sandboxOnly;
+            requirements(Category.crafting, BuildVisibility.sandboxOnly, with());
             size = 1;
             output = 10;
             ambientSound = Sounds.none;

--- a/src/aquarion/world/blocks/ConsumeRT.java
+++ b/src/aquarion/world/blocks/ConsumeRT.java
@@ -19,10 +19,10 @@ public class ConsumeRT extends Consume {
         this.amount = amount;
     }
     @Override public float efficiency(Building build) {
-        return build instanceof HasRT b ? Mathf.clamp(Math.abs(b.rotationPower) - amount) : 0f;
+        return build instanceof HasRT ? Mathf.clamp(Math.abs(((HasRT) build).rotationPower().rotationPower) - amount) : 0f;
     }
     @Override public float efficiencyMultiplier(Building build) {
-        return build instanceof HasRT b ? 1f + Mathf.map(Math.abs(b.rotationPower), amount, amount, 0, 1) : 0f;
+        return build instanceof HasRT ? 1f + Mathf.map(Math.abs(((HasRT) build).rotationPower().rotationPower), amount, amount, 0, 1) : 0f;
     }
 
 }

--- a/src/aquarion/world/blocks/distribution/PayloadTram.java
+++ b/src/aquarion/world/blocks/distribution/PayloadTram.java
@@ -164,7 +164,7 @@ public class PayloadTram extends PayloadBlock {
                 moveOutPayload();
             }
             Building link = world.build(this.link);
-            var other = (PayloadTramBuild) link;
+            PayloadTramBuild other = (PayloadTramBuild) link;
             if(linkValid()){
                 if(payload != null) {
                     updatePayload();
@@ -252,7 +252,7 @@ public class PayloadTram extends PayloadBlock {
             Draw.rect(capRegion, x, y);
             if (linkValid()) {
                 Building link = world.build(this.link);
-                var other = (PayloadTramBuild) link;
+                PayloadTramBuild other = (PayloadTramBuild) link;
                 float x1 = this.x;
                 float x2 = other.x;
                 float y1 = this.y;
@@ -300,7 +300,7 @@ public class PayloadTram extends PayloadBlock {
             Lines.stroke(1f);
             Drawf.circles(x, y, (tile.block().size / 2f + 1) * tilesize + sin - 2f, Pal.accent);
 
-            for (var shooter : waitingTram) {
+            for (Building shooter : waitingTram) {
                 Drawf.circles(shooter.x, shooter.y, (tile.block().size / 2f + 1) * tilesize + sin - 2f, Pal.place);
                 Drawf.arrow(shooter.x, shooter.y, x, y, size * tilesize + sin, 4f + sin, Pal.place);
             }
@@ -314,7 +314,8 @@ public class PayloadTram extends PayloadBlock {
         }
 
         protected boolean linkValid() {
-            return link != -1 && world.build(this.link) instanceof PayloadTramBuild other && other.block == block && other.team == team && within(other, range);
+            Building other = world.build(this.link);
+            return link != -1 && other instanceof PayloadTramBuild && other.block == block && other.team == team && within(other, range);
         }
 
         @Override

--- a/src/aquarion/world/blocks/distribution/SealedConveyor.java
+++ b/src/aquarion/world/blocks/distribution/SealedConveyor.java
@@ -121,7 +121,7 @@ public class SealedConveyor extends Duct implements Autotiler{
             Building next = front(), prev = back();
             capped = next == null || next.team != team || !next.block.hasItems;
             backCapped = blendbits == 0 && (prev == null || prev.team != team || !prev.block.hasItems);
-            nextc = next instanceof Conveyor.ConveyorBuild d ? d : null;
+            nextc = next instanceof Conveyor.ConveyorBuild ? (Conveyor.ConveyorBuild) next : null;
         }
 
         @Override

--- a/src/aquarion/world/blocks/rotPower/RTWallCrafter.java
+++ b/src/aquarion/world/blocks/rotPower/RTWallCrafter.java
@@ -42,6 +42,7 @@ public class RTWallCrafter extends WallCrafter {
 
         addBar("drillspeed", (WallCrafterBuild e) ->
                 new Bar(() -> Core.bundle.format("bar.drillspeed", Strings.fixed(e.lastEfficiency * 60 / drillTime, 2)), () -> Pal.ammo, () -> e.warmup));
+        rtConfig.addBars(this);
     }
 
     public class RTWallCrafterBuild extends WallCrafterBuild implements HasRT {

--- a/src/aquarion/world/interfaces/HasRT.java
+++ b/src/aquarion/world/interfaces/HasRT.java
@@ -25,7 +25,7 @@ public interface HasRT extends Buildingc {
     }
 
     default Seq<HasRT> nextBuilds() {
-        return proximity().select(b -> b instanceof HasRT other && connects(other)).map(b -> ((HasRT) b).getRTDest(this)).removeAll(b -> !connects(b) && !b.connects(this));
+        return proximity().select(b -> b instanceof HasRT && connects((HasRT) b)).map(b -> ((HasRT) b).getRTDest(this)).removeAll(b -> !connects(b) && !b.connects(this));
     }
 
     RTModule rotationPower();

--- a/src/aquarion/world/meta/RTModule.java
+++ b/src/aquarion/world/meta/RTModule.java
@@ -10,7 +10,7 @@ import mindustry.world.modules.BlockModule;
  * only holds a graph so that it's easier to change it
  */
 public class RTModule extends BlockModule {
-    public RTGraph graph = new aquarion.world.graphs.RTGraph();
+    public RTGraph graph = new RTGraph();
     public float rotationPower;
 
     @Override


### PR DESCRIPTION
Apart from fixing the erros that kept the mod from compiling, this pr:
- Moves the torque source to the same category as the shaft, to make it easier to place, as it is no longer needed to switch categories to when placing torque related blocks in sandbox.
- Makes the wallcrafter display the bars that rtconfig does, similarly to the other torque related blocks.